### PR TITLE
[mcdiscordbridgebot] Add initial code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+data/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "2"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    ports:
+      - 22181:2181
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    ports:
+      - 29092:29092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+  mcdiscordbridgebot:
+    image: mcdiscordbridgebot:latest
+    depends_on:
+      - kafka
+    build:
+      context: ./
+      dockerfile: mcdiscordbridgebot.Dockerfile
+    environment:
+      - KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - KAFKA_CONSUMER_TOPIC=todiscord
+      - KAFKA_PRODUCER_TOPIC=tomc
+      - DEBUG_GUILD_ID=${DEBUG_GUILD_ID}
+      - MC_SERVER_IP=${MC_SERVER_IP}
+      - DISCORD_TOKEN=${DISCORD_TOKEN}
+    volumes:
+      - mcdiscordbridgebot_data:/app/data
+volumes:
+  mcdiscordbridgebot_data:

--- a/mcdiscordbridgebot.Dockerfile
+++ b/mcdiscordbridgebot.Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12.2-slim-bullseye
+
+WORKDIR /app
+
+COPY requirements.txt .
+COPY mcdiscordbridgebot/ mcdiscordbridgebot/
+
+RUN [ "pip", "install", "--no-cache-dir", "-r", "requirements.txt" ]
+
+LABEL maintainer="gochewjawn <gochewjawn@outlook.com>"
+LABEL version="1.0.0"
+LABEL description="Minecraft, Discord messaging bridge bot"
+
+CMD [ "python", "-m", "mcdiscordbridgebot" ]

--- a/mcdiscordbridgebot/__main__.py
+++ b/mcdiscordbridgebot/__main__.py
@@ -1,0 +1,12 @@
+from .bot import McDiscordBridgeBot
+from .database import load_database
+from .config import create_config_from_environment
+from discord.utils import setup_logging
+from logging import FileHandler, INFO
+
+if __name__ == "__main__":
+    config = create_config_from_environment()
+    setup_logging(handler=FileHandler(config.log_path), level=INFO)
+    with load_database(config.database_path) as db:
+        bot = McDiscordBridgeBot(config, db)
+        bot.run(config.discord_token)

--- a/mcdiscordbridgebot/bot.py
+++ b/mcdiscordbridgebot/bot.py
@@ -1,0 +1,34 @@
+from .config import Config
+from .database import Database
+from dataclasses import dataclass
+from discord.ext import commands
+from discord import  Intents
+from logging import getLogger
+
+_logger = getLogger(__name__)
+
+
+class McDiscordBridgeBot(commands.Bot):
+    def __init__(self, config: Config, database: Database) -> None:
+        super().__init__("!", intents=create_intents())
+        self.config = config
+        self.database = database
+
+    async def on_ready(self) -> None:
+        await self.load_extension("mcdiscordbridgebot.cogs.ownercog")
+        await self.load_extension("mcdiscordbridgebot.cogs.consumercog")
+        await self.load_extension("mcdiscordbridgebot.cogs.producercog")
+        await self.load_extension("mcdiscordbridgebot.cogs.statuscog")
+        _logger.info("Loaded extensions")
+
+
+@dataclass
+class McMessage:
+    author: str
+    content: str
+
+
+def create_intents() -> Intents:
+    intents = Intents.default()
+    intents.message_content = True
+    return intents

--- a/mcdiscordbridgebot/cogs/consumercog.py
+++ b/mcdiscordbridgebot/cogs/consumercog.py
@@ -1,0 +1,58 @@
+from ..bot import McDiscordBridgeBot, McMessage
+from aiokafka import AIOKafkaConsumer
+from asyncio import Task, get_event_loop
+from discord.ext import commands
+from discord import Interaction, app_commands
+from json import loads
+
+
+class ConsumerCog(commands.Cog):
+    def __init__(self, bot: McDiscordBridgeBot) -> None:
+        self.bot = bot
+        self.consumer = AIOKafkaConsumer(
+            self.bot.config.kafka_consumer_topic,
+            bootstrap_servers=self.bot.config.kafka_bootstrap_servers,
+            value_deserializer=deserialize_minecraft_message,
+        )
+        self.consumer_task: Task | None = None
+
+    async def cog_load(self) -> None:
+        await self.consumer.start()
+        self.consumer_task = get_event_loop().create_task(self.create_consumer_task())
+
+    async def create_consumer_task(self) -> None:
+        async for msg in self.consumer:
+            await self.send_to_consumer_channels(msg.value)
+
+    async def send_to_consumer_channels(self, msg: McMessage) -> None:
+        for id in self.bot.database.consumer_channel_ids:
+            chan = self.bot.get_channel(id) or await self.bot.fetch_channel(id)
+            await chan.send(f"**{msg.author}**: {msg.content}")
+
+    @app_commands.command(
+        name="addconsumerchannel",
+        description="Sets up a channel to receive messages from Minecraft",
+    )
+    async def add_consumer_channel(self, inter: Interaction) -> None:
+        if inter.channel_id:
+            cids = set(self.bot.database.consumer_channel_ids) | {inter.channel_id}
+            self.bot.database.consumer_channel_ids = list(cids)
+            await inter.response.send_message(
+                "This channel will now receive messages from Minecraft! 😍"
+            )
+        else:
+            await inter.response.send_message(
+                f"Sorry, {inter.author.mention}. You sure you're in a channel?"
+            )
+
+    async def cog_unload(self) -> None:
+        self.consumer_task and self.consumer_task.cancel()
+        await self.consumer.stop()
+
+
+def deserialize_minecraft_message(msg: bytes) -> McMessage:
+    return McMessage(**loads(msg))
+
+
+async def setup(bot: McDiscordBridgeBot) -> None:
+    await bot.add_cog(ConsumerCog(bot))

--- a/mcdiscordbridgebot/cogs/ownercog.py
+++ b/mcdiscordbridgebot/cogs/ownercog.py
@@ -1,0 +1,20 @@
+from ..bot import McDiscordBridgeBot
+from discord.ext import commands
+
+
+class OwnerCog(commands.Cog):
+    def __init__(self, bot: McDiscordBridgeBot) -> None:
+        self.bot = bot
+
+    @commands.command(name="syncappcommands")
+    @commands.is_owner()
+    async def sync_application_commands(self, ctx: commands.Context) -> None:
+        if gid := self.bot.config.debug_guild_id:
+            debug_guild = self.bot.get_guild(gid) or await self.bot.fetch_guild(gid)
+            self.bot.tree.copy_global_to(guild=debug_guild)
+        await self.bot.tree.sync(guild=ctx.guild)
+        await ctx.message.reply("Synced!")
+
+
+async def setup(bot: McDiscordBridgeBot) -> None:
+    await bot.add_cog(OwnerCog(bot))

--- a/mcdiscordbridgebot/cogs/producercog.py
+++ b/mcdiscordbridgebot/cogs/producercog.py
@@ -1,0 +1,61 @@
+from ..bot import McDiscordBridgeBot, McMessage
+from aiokafka import AIOKafkaProducer
+from discord.ext import commands
+from discord import Interaction, Message as DiscordMessage, app_commands
+from json import dumps
+from logging import getLogger
+
+_logger = getLogger(__name__)
+
+
+class ProducerCog(commands.Cog):
+    def __init__(self, bot: McDiscordBridgeBot) -> None:
+        self.bot = bot
+        self.producer = AIOKafkaProducer(
+            bootstrap_servers=self.bot.config.kafka_bootstrap_servers,
+            value_serializer=serialize_minecraft_message,
+        )
+
+    async def cog_load(self) -> None:
+        await self.producer.start()
+
+    async def cog_unload(self) -> None:
+        await self.producer.stop()
+
+    @app_commands.command(
+        name="addproducerchannel",
+        description="Sets up a channel to send messages to Minecraft",
+    )
+    async def add_producer_channel(self, inter: Interaction) -> None:
+        if inter.channel_id:
+            cids = set(self.bot.database.producer_channel_ids) | {inter.channel_id}
+            self.bot.database.producer_channel_ids = list(cids)
+            await inter.response.send_message(
+                "This channel will now send messages to Minecraft! 😍"
+            )
+        else:
+            await inter.response.send_message(
+                f"Sorry, {inter.author.mention}. You sure you're in a channel?"
+            )
+
+    @commands.Cog.listener()
+    async def on_message(self, msg: DiscordMessage) -> None:
+        checks = (
+            not msg.author.bot,
+            msg.channel.id in self.bot.database.producer_channel_ids,
+        )
+        if all(checks):
+            mc_msg = McMessage(author=msg.author.name, content=msg.content)
+            _logger.info("Submitting Minecraft message to Kafka: %s", mc_msg)
+            await self.producer.send_and_wait(
+                self.bot.config.kafka_producer_topic,
+                value=mc_msg,
+            )
+
+
+def serialize_minecraft_message(msg: McMessage) -> bytes:
+    return dumps(msg.__dict__).encode()
+
+
+async def setup(bot: McDiscordBridgeBot) -> None:
+    await bot.add_cog(ProducerCog(bot))

--- a/mcdiscordbridgebot/cogs/statuscog.py
+++ b/mcdiscordbridgebot/cogs/statuscog.py
@@ -1,0 +1,38 @@
+from ..bot import McDiscordBridgeBot
+from discord.ext import commands, tasks
+from discord import Game
+from logging import getLogger
+from mcstatus import JavaServer
+from mcstatus.status_response import JavaStatusResponse
+
+import discord
+
+_logger = getLogger(__name__)
+
+
+class StatusCog(commands.Cog):
+    def __init__(self, bot: McDiscordBridgeBot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        self.query_server_task.start()
+
+    async def cog_unload(self) -> None:
+        self.query_server_task.cancel()
+
+    @tasks.loop(minutes=1)
+    async def query_server_task(self) -> None:
+        _logger.info("Querying Minecraft server status")
+        server = JavaServer.lookup(self.bot.config.mc_server_ip)
+        status = server.status()
+        await self.bot.change_presence(activity=self.create_activity_presence(status))
+
+    def create_activity_presence(self, status: JavaStatusResponse) -> Game:
+        return discord.Activity(
+            type=discord.ActivityType.watching,
+            name=f"{status.players.online} / {status.players.max} players",
+        )
+
+
+async def setup(bot: McDiscordBridgeBot) -> None:
+    await bot.add_cog(StatusCog(bot))

--- a/mcdiscordbridgebot/config.py
+++ b/mcdiscordbridgebot/config.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+from dotenv import load_dotenv
+from os import environ
+
+
+@dataclass
+class Config:
+    kafka_bootstrap_servers: list[str]
+    kafka_producer_topic: str  # Messages will be sent here from Discord.
+    kafka_consumer_topic: str  # Messages sent here will be replicated to Discord.
+    database_path: str  # Maintains which Discord channels are bridged to, bridged from.
+    log_path: str
+    discord_token: str
+    debug_guild_id: int
+    mc_server_ip: str  # Shows Minecraft server information as status.
+
+
+def create_config_from_environment() -> Config:
+    load_dotenv()
+    return Config(
+        kafka_bootstrap_servers=environ["KAFKA_BOOTSTRAP_SERVERS"].split(","),
+        kafka_producer_topic=environ["KAFKA_PRODUCER_TOPIC"],
+        kafka_consumer_topic=environ["KAFKA_CONSUMER_TOPIC"],
+        database_path=environ.get("DATABASE_PATH", "data/db.json"),
+        log_path=environ.get("LOG_PATH", "data/log.txt"),
+        discord_token=environ["DISCORD_TOKEN"],
+        debug_guild_id=int(environ.get("DEBUG_GUILD_ID", 0)),
+        mc_server_ip=environ["MC_SERVER_IP"],
+    )

--- a/mcdiscordbridgebot/database.py
+++ b/mcdiscordbridgebot/database.py
@@ -1,0 +1,38 @@
+from contextlib import contextmanager
+from dataclasses import dataclass
+from logging import getLogger
+from pathlib import Path
+from json import dump, load
+
+_logger = getLogger(__name__)
+
+
+@dataclass
+class Database:
+    consumer_channel_ids: list[int]
+    producer_channel_ids: list[int]
+
+
+def load_database_data(path: str) -> Database:
+    _logger.info("Loading database file")
+    try:
+        with open(path, "r") as file:
+            return Database(**load(file))
+    except FileNotFoundError:
+        _logger.info("Falling back to default database data")
+        return Database(consumer_channel_ids=[], producer_channel_ids=[])
+
+
+def save_database_data(database: Database, path: str) -> None:
+    _logger.info("Writing database to disk")
+    with Path(path) as path_obj:
+        path_obj.parent.mkdir(parents=True, exist_ok=True)
+        with path_obj.open("w") as file:
+            dump(database.__dict__, file, indent=4)
+
+
+@contextmanager
+def load_database(path: str):
+    database = load_database_data(path)
+    yield database
+    save_database_data(database, path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+aiohttp==3.9.3
+aiokafka==0.10.0
+aiosignal==1.3.1
+async-timeout==4.0.3
+asyncio-dgram==2.1.2
+attrs==23.2.0
+discord.py==2.3.2
+dnspython==2.6.1
+frozenlist==1.4.1
+idna==3.6
+mcstatus==11.1.1
+multidict==6.0.5
+packaging==23.2
+python-dotenv==1.0.1
+setuptools==68.2.2
+wheel==0.41.2
+yarl==1.9.4


### PR DESCRIPTION
- Adds initial code for `mcdiscordbridgebot`.
- Added `docker-compose.yml` that sets up Kafka & the bot.
- Make sure to invoke `docker-compose up -d --build` to always rebuild the bot image.

Helpful commands
- `docker-compose up -d --build`
- `docker exec -it mcdiscordbridge-mcdiscordbridgebot-1 bash`
- `docker-compose down` or `docker-compose down -v` (deletes volume containing logs & channel configurations)

Notes
- For development outside of container, create `.env` file according to `config.py`.
- For development with `docker-compose`, `.env` can omit everything but `DEBUG_GUILD_ID`, `MC_DISCORD_IP`, and `DISCORD_TOKEN`. `docker-compose.yml` will pull these from `.env` file to run the bot image.

![MinecraftDogGIF](https://github.com/gochewjawn/mcdiscordbridge/assets/157254554/8f55aece-9d61-4ffd-beb8-869c1d9dd9c3)